### PR TITLE
added token based security to recipe endpoints

### DIFF
--- a/services/recipeservice/pom.xml
+++ b/services/recipeservice/pom.xml
@@ -17,7 +17,7 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-<!--<dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
@@ -26,7 +26,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
--->
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/services/recipeservice/src/main/java/ch/whatshouldieat/services/recipeservice/security/SecurityConfig.java
+++ b/services/recipeservice/src/main/java/ch/whatshouldieat/services/recipeservice/security/SecurityConfig.java
@@ -1,6 +1,26 @@
 package ch.whatshouldieat.services.recipeservice.security;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
-    //TODO
-    
+   
+   @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                .authorizeHttpRequests(authorize -> authorize
+                    //only with valid token
+                    .requestMatchers("/recipe/**")
+                    .authenticated()            
+                )
+                .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt
+                );
+            return http.build();
+    }
 }

--- a/services/recipeservice/src/main/resources/application.properties
+++ b/services/recipeservice/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.uri=${MONGO_DB_URI:mongodb://localhost:27017/docker-db}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_V5cEAto6w


### PR DESCRIPTION
/recipe endpoints are now only accessible with a jwt bearer token issued from cognito IdP. To get a token, you have to fetch one with the frontend for now.